### PR TITLE
fix problem with escaping backslash

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -79,7 +79,7 @@ function! previm#convert_to_content(lines)
   let converted_lines = []
   " TODO リストじゃなくて普通に文字列連結にする(テスト書く)
   for line in a:lines
-    let escaped = substitute(line, '\', '\\\\\\', 'g')
+    let escaped = substitute(line, '\', '\\\\', 'g')
     let escaped = substitute(escaped, '"', '\\"', 'g')
     let escaped = previm#relative_to_absolute_imgpath(escaped, mkd_dir)
     call add(converted_lines, escaped)


### PR DESCRIPTION
バックスラッシュのエスケープ処理が間違っているように思います。
例えば、`\b` は `\\\b` に変換され、バックスラッシュ + バックスペースとして扱われてしまいます。
