### PR TITLE
Fix incorrect path when running vim from cygwin

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -84,6 +84,10 @@ endfunction
 
 function! previm#convert_to_content(lines)
   let mkd_dir = s:escape_backslash(expand('%:p:h'))
+  if has("win32unix")
+    " convert cygwin path to windows path
+    let mkd_dir = s:escape_backslash(substitute(system('cygpath -wa ' . mkd_dir), "\n$", '', ''))
+  endif
   let converted_lines = []
   " TODO リストじゃなくて普通に文字列連結にする(テスト書く)
   for line in a:lines


### PR DESCRIPTION
素晴らしいプラグインを作って頂いてありがとうございます。

こちらはcygwin上でVimを動かしていますが、画像を入れた場合、パスは`file:///cygdrive/c/...`のようになってしまい、ブラウザ上で見れなくなってしまう問題がありました。

これを修正するためにちょっとコードを追加させて頂きました。
