### PR TITLE
add compound filetype support

### DIFF
--- a/preview/js/previm.js
+++ b/preview/js/previm.js
@@ -4,7 +4,7 @@
   var REFRESH_INTERVAL = 1000;
 
   function transform(filetype, content) {
-    if (filetype === 'markdown' || filetype === 'mkd') {
+    if(hasTargetFileType(filetype, ['markdown', 'mkd'])) {
       marked.setOptions({
         langPrefix: '',
         highlight: function (code) {
@@ -12,13 +12,23 @@
         }
       });
       return marked(content);
-    } else if (filetype === 'rst') {
+    } else if(hasTargetFileType(filetype, ['rst'])) {
       // It has already been converted by rst2html.py
       return content;
-    } else if (filetype === 'textile') {
+    } else if(hasTargetFileType(filetype, ['textile'])) {
       return textile(content);
     }
     return 'Sorry. It is a filetype(' + filetype + ') that is not support<br /><br />' + content;
+  }
+
+  function hasTargetFileType(filetype, targetList) {
+    var ftlist = filetype.split('.');
+    for(var i=0;i<ftlist.length; i++) {
+      if(targetList.indexOf(ftlist[i]) > -1){
+        return true;
+      }
+    }
+    return false;
   }
 
   function loadPreview() {


### PR DESCRIPTION
ドット区切りで複数のファイルタイプが指定されている場合への対応を書いてみました。
たとえば、uikiのファイルをMarkdownしてプレビューしたい、というようなときを想定しています。
私は本Pull requestの変更をした上で.vimrcに以下のような記述をして使っています。

```
augroup PrevimSettings
  autocmd!
  autocmd FileType uiki set filetype=markdown | set filetype=uiki.markdown
augroup END
```

懸念
- plugin/previm.vim 内の以下の箇所にも同様の対応を加えた方がよい？  
  `autocmd FileType markdown,rst,textile call <SID>setup_setting()`  
- filetype ごとにプレビュー形式を設定できる等のようにする等がスマート？

ご検討ください。
