### PR TITLE
modified the separator of file path "\" -> "/"

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -69,7 +69,7 @@ endfunction
 
 let s:base_dir = expand('<sfile>:p:h')
 function! previm#make_preview_file_path(path)
-  return s:base_dir . '/../preview/' . a:path
+  return substitute(s:base_dir, "\\", "/", "g") . '/../preview/' . a:path
 endfunction
 
 " NOTE: getFileType()の必要性について。


### PR DESCRIPTION
Previmいつも便利に使わせていただいています。

Windows7/ Kaori-ya vim/ Previm /open-browserの環境です。
#46 のissueに関連するかと思うのですが、

私の環境では`s:base_dir`もファイルパスがバックスラッシュを含んでいて
Previmでブラウザを開くことができませんでした。

他の環境では調査出来ていないので、暫定的な対処ではありますがご精査いただけると助かります。
