### PR TITLE
fix file path if preview_html_file is absolute path

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -14,7 +14,11 @@ function! previm#open(preview_html_file)
     call s:system(g:previm_open_cmd . ' '''  . a:preview_html_file . '''')
   elseif s:exists_openbrowser()
     " fix temporary(the cause unknown)
-    call s:apply_openbrowser('file:///' . a:preview_html_file)
+    let rootslash = ""
+    if a:preview_html_file[0] != "/"
+      let rootslash = "/"
+    endif
+    call s:apply_openbrowser('file://' . rootslash . a:preview_html_file)
   else
     call s:echo_err('Command for the open can not be found. show detail :h previm#open')
   endif


### PR DESCRIPTION
大変便利なプラグインで重宝しています。
ただ、Cygwinで:PrevimOpenすると、以下のメッセージが表示された状態で、ブラウザが開きませんでした。

```
opening 'file:////home/hogehoge/.vim/bundle/previm/autoload/../preview/index.html' ... done! (cygstart)       
```

環境は以下の通りです。
- Win10 64bit
- cygwin 2.5.1-1 x86_64
- vim-markdown + previm + open-browser

URLが'file:////'になっているのが問題なのかと思い、以下のように17行目で 'file:///' を 'file://' に修正したところうまくいきました。

```
call s:apply_openbrowser('file://' . a:preview_html_file)
```

なので、a:preview_html_fileが絶対パスの場合はスラッシュが3つになるように修正してみました。

なお、macやkaoriya vim版では上記の事象が発生しなかったのでCygwin環境だけの問題かもしれません。(修正後もmacやkaoriya vimで正常に動作しています）
