### PR TITLE
Ignore changes in the preview dir (apart from _)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-preview/_
+preview/**
+!preview/_
 doc/tags*


### PR DESCRIPTION
When cloning previm into the vim plugins dir it will show as dirty as previews accumulate in the preview dir. This .gitignore change will ignore them but still include the "_" dir which appears to have useful files in it. Note the "_" was ignored previously in .gitignore which I have reversed, I assume this was a mistake.