### PR TITLE
Fixed bug that can not be recognized correctly if illegal characters …

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -14,7 +14,7 @@ function! previm#open(preview_html_file) abort
   if exists('g:previm_open_cmd') && !empty(g:previm_open_cmd)
     if has('win32') || has('win64') && g:previm_open_cmd =~? 'firefox'
       " windows+firefox環境
-      call s:system(g:previm_open_cmd . ' "'  . substitute(a:preview_html_file,'\/','\\','g') . '"')
+      call s:system(g:previm_open_cmd . ' "file:///'  . fnamemodify(a:preview_html_file, ':p:gs?\\?/?g') . '"')
     elseif has('win32unix') || has('win64unix')
       call s:system(g:previm_open_cmd . ' '''  . system('cygpath -w ' . a:preview_html_file) . '''')
     else


### PR DESCRIPTION
…are included in the file path.

Fixed bug that can not be recognized correctly if illegal characters are included in the file path.

This pull request #86 .

\a や \repo のファイルパスの場合、コントロールコードと認識され正しく開けなかったので修正しました。ファイルプロトコルも付ける事で、\ではなく、/でも確実に開くように対応。

(付近のコードが冗長になってきてまとめれそうな気がしますが、cygwin環境とか不明です・・・)