### PR TITLE
fix image paths on Windows that cause not appearing local image in br…

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -196,6 +196,7 @@ function! previm#convert_to_content(lines) abort
   if has('win32unix')
     " convert cygwin path to windows path
     let mkd_dir = s:escape_backslash(substitute(system('cygpath -wa ' . mkd_dir), "\n$", '', ''))
+    let mkd_dir = substitute(mkd_dir, '\\', '/', 'g')
   elseif has('win32') || has('win64')
     let mkd_dir = substitute(mkd_dir, '\\', '/', 'g')
   endif

--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -200,10 +200,10 @@ function! previm#convert_to_content(lines) abort
   let mkd_dir = s:escape_backslash(expand('%:p:h'))
   if has('win32unix')
     " convert cygwin path to windows path
-    let mkd_dir = s:escape_backslash(substitute(system('cygpath -wa ' . mkd_dir), "\n$", '', ''))
-    let mkd_dir = substitute(mkd_dir, '\\', '/', 'g')
+    let mkd_dir = substitute(system('cygpath -wa ' . mkd_dir), "\n$", '', '')
+    let mkd_dir = substitute(mkd_dir, '\', '/', 'g')
   elseif has('win32')
-    let mkd_dir = substitute(mkd_dir, '\\', '/', 'g')
+    let mkd_dir = substitute(mkd_dir, '\', '/', 'g')
   endif
   let converted_lines = []
   for line in s:do_external_parse(a:lines)


### PR DESCRIPTION
…owser

いつもお世話になっております。
ご確認のほど、よろしくお願い致します。

# 問題/Problem
## 日本語
#5 
の通り、Windows環境においてローカル画像が表示されませんでした。
## English
Like #5, it seems that local image does not appear in Windows.

# 修正結果/Result
## 日本語
- Git-Bash
- Cygwin
を使用したWindows環境においてローカル画像が表示されるようになりました。

## English
- Git-Bash
- Cygwin
In above environment in Windows, local image appears in Windows.

# 動作確認済環境/Checked Environment
- Windows10 + Cygwin64 + Vim 8.0.1567 + tyru/openbrowser.vim
- Windows10 + Git-Bash + Vim 8.1 + tyru/openbrowser.vim
- Ubuntu 16.04.03LTS + Terminal + Vim 7.4.1689 + tyru/openbrowser.vim