### PR TITLE
Fix the condition to judge as win & firefox environment.

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -12,7 +12,7 @@ let s:newline_character = "\n"
 function! previm#open(preview_html_file) abort
   call previm#refresh()
   if exists('g:previm_open_cmd') && !empty(g:previm_open_cmd)
-    if has('win32') || has('win64') && g:previm_open_cmd =~? 'firefox'
+    if (has('win32') || has('win64')) && g:previm_open_cmd =~? 'firefox'
       " windows+firefox環境
       call s:system(g:previm_open_cmd . ' "'  . substitute(a:preview_html_file,'\/','\\','g') . '"')
     elseif has('win32unix') || has('win64unix')

--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -12,7 +12,7 @@ let s:newline_character = "\n"
 function! previm#open(preview_html_file) abort
   call previm#refresh()
   if exists('g:previm_open_cmd') && !empty(g:previm_open_cmd)
-    if (has('win32') || has('win64')) && g:previm_open_cmd =~? 'firefox'
+    if has('win32') && g:previm_open_cmd =~? 'firefox'
       " windows+firefox環境
       call s:system(g:previm_open_cmd . ' "'  . substitute(a:preview_html_file,'\/','\\','g') . '"')
     elseif has('win32unix') || has('win64unix')
@@ -23,7 +23,7 @@ function! previm#open(preview_html_file) abort
   elseif s:exists_openbrowser()
     let path = a:preview_html_file
     " fix temporary(the cause unknown)
-    if has('win32') || has('win64')
+    if has('win32')
       let path = fnamemodify(path, ':p:gs?\\?/?g')
     elseif has('win32unix') || has('win64unix')
       let path = substitute(path,'\/','','')
@@ -196,7 +196,7 @@ function! previm#convert_to_content(lines) abort
   if has('win32unix')
     " convert cygwin path to windows path
     let mkd_dir = s:escape_backslash(substitute(system('cygpath -wa ' . mkd_dir), "\n$", '', ''))
-  elseif has('win32') || has('win64')
+  elseif has('win32')
     let mkd_dir = substitute(mkd_dir, '\\', '/', 'g')
   endif
   let converted_lines = []


### PR DESCRIPTION
Added parentheses to the condition to judge as win & firefox.
Under the condition before modification, if I set chrome command in windows, previm judge as win & firefox. As a result, previm was trying to open an incorrect file path with chrome and got into file not found error.