### PR TITLE
prefer rst2html than rst2html.py on Windows

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -175,12 +175,17 @@ function! s:do_external_parse(lines) abort
   " NOTE: 本来は外部コマンドに頼りたくない
   "       いずれjsパーサーが出てきたときに移行するが、
   "       その時に混乱を招かないように設定でrst2htmlへのパスを持つことはしない
+  let candidates = ['rst2html.py', 'rst2html']
   let cmd = ''
-  if executable('rst2html.py') ==# 1
-    let cmd = 'rst2html.py'
-  elseif executable('rst2html') ==# 1
-    let cmd = 'rst2html'
+  if has('win32') || has('win64')
+    let candidates = reverse(candidates)
   endif
+  for candidate in candidates
+    if executable('rst2html.py') ==# 1
+      let cmd = candidate
+      break
+    endif
+  endfor
 
   if empty(cmd)
     call s:echo_err('rst2html.py or rst2html has not been installed, you can not run')


### PR DESCRIPTION
On Windows, executable("rst2html.py") return 1 even though if .py is not
registered to python.exe. So rst2html should be handled before
rst2html.py.