### PR TITLE
add previm_wsl_mode

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -17,6 +17,8 @@ function! previm#open(preview_html_file) abort
       call s:system(g:previm_open_cmd . ' "file:///'  . fnamemodify(a:preview_html_file, ':p:gs?\\?/?g') . '"')
     elseif has('win32unix')
       call s:system(g:previm_open_cmd . ' '''  . system('cygpath -w ' . a:preview_html_file) . '''')
+    elseif get(g:, 'previm_wsl_mode', 0) ==# 1
+      call s:system(g:previm_open_cmd . ' '''  . system('wslpath -w ' . a:preview_html_file) . '''')
     else
       call s:system(g:previm_open_cmd . ' '''  . a:preview_html_file . '''')
     endif


### PR DESCRIPTION
Windows Subsystem for Linux(WSL)に対応するためのモードです。

`.vimrc` にて、`let g:previm_wsl_mode = 1` と指定することで、WSL上のLinuxから `g:previm_open_cmd` で指定したブラウザで開くことができます。

#### example
```vim:example
let g:previm_open_cmd = '/mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe'
let g:previm_wsl_mode = 1
```

#### 詳細
WSL上で実行される `a:preview_html_file` は、Linuxと同様に `/home/hirano00o/.vim/.../index.html` となり、Windowsから見えるパスとは異なります。
WSL <-> Windows のパス変換をするために、`wslpath` を利用します。
`wslpath` は、WSL では標準で利用できます。

この `wslpath` を利用し、`g:previm_wsl_mode = 1` のときは、
`wslpath -w a:preview_html_file`
 を実行し、
`/home/hirano00o/.vim.../index.html` -> `\\wsl$\Ubuntu\home\hirano00o/.vim/.../index.html`
と変換してWindowsのブラウザへ渡すことで、表示することが可能です。

`g:previm_wsl_mode` が、`1` 以外、または.vimrcで指定されていない場合は、elseifをスルーします。