### PR TITLE
fix previm_wsl_mode for fish shell

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -18,7 +18,8 @@ function! previm#open(preview_html_file) abort
     elseif has('win32unix')
       call s:system(g:previm_open_cmd . ' '''  . system('cygpath -w ' . a:preview_html_file) . '''')
     elseif get(g:, 'previm_wsl_mode', 0) ==# 1
-      call s:system(g:previm_open_cmd . ' '''  . system('wslpath -w ' . a:preview_html_file) . '''')
+      let l:wsl_file_path = system('wslpath -w ' . a:preview_html_file)
+      call s:system(g:previm_open_cmd . " 'file:///" . fnamemodify(l:wsl_file_path, ':gs?\\?\/?') . '''')
     else
       call s:system(g:previm_open_cmd . ' '''  . a:preview_html_file . '''')
     endif


### PR DESCRIPTION
https://github.com/previm/previm/pull/135 で追加された`previm_wsl_mode`をfish shellから使用した場合に、`:PrevimOpen`をしてもpreviewをブラウザで開くことができなかったため修正しました。

### 環境

 * Windows 10
 * WSL
 * fish: version 3.0.2-1910-g9efb7fd5

### 原因

シェルで`{ブラウザの実行ファイルへのパス} '{ファイルパス}'`を実行した場合に、shやbashとfishではファイルパスの解釈の仕方が違うようです。
そのためfishから実行するとpreview用のファイルにアクセスできなくなっていました。

ex)
**bash × Chrome**
```
$ /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe '\\wsl$\Ubuntu\home\ryotatake\test.md'
=> file://wsl%24/Ubuntu/home/ryotatake/test.md がブラウザで開かれる。
```

**fish × Chrome**
```
$ /mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe '\\wsl$\Ubuntu\home\ryotatake\test.md'
=> http://www.wsl%24/Ubuntu/home/ryotatake/test.md がブラウザで開かれる。
```

**bash × Firefox**
```
$ /mnt/c/Program\ Files/Mozilla\ Firefox/firefox.exe '\\wsl$\Ubuntu\home\ryotatake\test.md'
=> file://///wsl$/Ubuntu/home/ryotatake/test.md がブラウザで開かれる。
```

**fish × Firefox**
```
$ /mnt/c/Program\ Files/Mozilla\ Firefox/firefox.exe '\\wsl$\Ubuntu\home\ryotatake\test.md'
=> http://www.wsl$.com/Ubuntu/home/ryotatake/test.md がブラウザで開かれる。
```

### 行ったこと

ファイルパスを渡す際にスキーム名まで明記することで、実行するシェルに関わらず正しく動くようにしました。

### 動作確認

* シェル：bash, fish
* ブラウザ：Chrome, Firefox, Opera

この6通りの組み合わせで問題なく動くことを確認しました。