### PR TITLE
fix: gitignore do not run autocrlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8 ff=unix
+
+# git system files
+.gitattributes  eol=lf
+# gitignore contains Icon^M <- CRLF end
+# skip autocrlf,diff enable -> not binary, set -text
+.gitignore      -text
+
+# EOF


### PR DESCRIPTION
When autocrlf off/linux checkout, file modification detect by git

Reason:
gitignore has mac icon define,that is 
```
# Icon must end with two \r
Icon^M
```
Then git mis-detect CRLF/LF