### PR TITLE
Fix imgpath in wsl_mode.

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -217,6 +217,9 @@ function! previm#convert_to_content(lines) abort
     " convert cygwin path to windows path
     let mkd_dir = substitute(system('cygpath -wa ' . mkd_dir), "\n$", '', '')
     let mkd_dir = substitute(mkd_dir, '\', '/', 'g')
+  elseif get(g:, 'previm_wsl_mode', 0) ==# 1
+    let mkd_dir = substitute(system('wslpath -w ' . mkd_dir), "\n$", '', '')
+    let mkd_dir = substitute(mkd_dir, '\', '/', 'g')
   elseif has('win32')
     let mkd_dir = substitute(mkd_dir, '\', '/', 'g')
   endif
@@ -267,6 +270,9 @@ function! previm#relative_to_absolute_imgpath(text, mkd_dir) abort
   let prev_imgpath = ''
   let new_imgpath = ''
   let path_prefix = '//localhost'
+  if get(g:, 'previm_wsl_mode', 0) ==# 1
+    let path_prefix = ''
+  endif
   if s:start_with(local_path, 'file://')
     let path_prefix = ''
     let local_path = local_path[7:]

--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -218,7 +218,7 @@ function! previm#convert_to_content(lines) abort
     let mkd_dir = substitute(system('cygpath -wa ' . mkd_dir), "\n$", '', '')
     let mkd_dir = substitute(mkd_dir, '\', '/', 'g')
   elseif get(g:, 'previm_wsl_mode', 0) ==# 1
-    let mkd_dir = substitute(system('wslpath -w ' . mkd_dir), "\n$", '', '')
+    let mkd_dir = trim(system('wslpath -w ' . mkd_dir))
     let mkd_dir = substitute(mkd_dir, '\', '/', 'g')
   elseif has('win32')
     let mkd_dir = substitute(mkd_dir, '\', '/', 'g')


### PR DESCRIPTION
## Overview

Thanks for a useful plugin.
This PR fix the path to image in markdown when `let g:previm_wsl_mode = 1`.

## Before

WSL was treated as Unix, and the following path was generated.
`![alt](file://localhost/home/halkn/Pictures/img.png "title")`
But in WSL, paths like above cannot be opened from Windows browser.

## After
Use wslpath to convert to a path that can be referenced from Windows browser.
`![alt](\\wsl$\Ubuntu\home\halkn\Pictures\img.png "title")`