### PR TITLE
Add `PrevimRefresh` command

### DIFF
--- a/plugin/previm.vim
+++ b/plugin/previm.vim
@@ -23,6 +23,7 @@ function! s:install_previm() abort
 
   command! -buffer -nargs=0 PrevimOpen call previm#open(previm#make_preview_file_path('index.html'))
   command! -buffer -nargs=0 PrevimWipeCache call previm#wipe_cache()
+  command! -buffer -nargs=0 PrevimRefresh call previm#refresh()
 endfunction
 
 augroup Previm


### PR DESCRIPTION
Making `previm#refresh()` as a user command is something bad?

In case realtime preview is off (`g:previm_enable_realtime = 0`),
writing the file, or calling `PrevimOpen` newly is only the way to update the preview now.