### PR TITLE
Set default link target `_blank`

### DIFF
--- a/preview/_/index.html
+++ b/preview/_/index.html
@@ -1,7 +1,9 @@
+<!-- vim: set ft=html et ts=4 sts=4 sw=4: -->
 <!DOCTYPE html>
 <html>
     <head>
         <meta charset="UTF-8">
+        <base target="_blank">
         <title>Preview</title>
         <link type="text/css" href="css/previm.css" rel="stylesheet" media="all" />
         <link type="text/css" href="../_/css/lib/mermaid.min.css" rel="stylesheet" media="all" />


### PR DESCRIPTION
Current link target is the preview page itself (i.e. `target="_self"`).
However, going back from a link page, it takes a while to reload the preview.

Instead, shouldn't it open links in new tabs?
