### PR TITLE
Skip refresh if browser has not been opened on a buffer

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -10,7 +10,7 @@ let s:File = vital#previm#import('System.File')
 let s:newline_character = "\n"
 
 function! previm#open(preview_html_file) abort
-  let b:opened = 1
+  let b:previm_opened = 1
   call previm#refresh()
   if exists('g:previm_open_cmd') && !empty(g:previm_open_cmd)
     if has('win32') && g:previm_open_cmd =~? 'firefox'
@@ -59,7 +59,7 @@ function! s:apply_openbrowser(path) abort
 endfunction
 
 function! previm#refresh() abort
-  if exists('b:opened')
+  if exists('b:previm_opened')
     call previm#refresh_css()
     call previm#refresh_js()
   endif

--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -10,6 +10,7 @@ let s:File = vital#previm#import('System.File')
 let s:newline_character = "\n"
 
 function! previm#open(preview_html_file) abort
+  let b:opened = 1
   call previm#refresh()
   if exists('g:previm_open_cmd') && !empty(g:previm_open_cmd)
     if has('win32') && g:previm_open_cmd =~? 'firefox'
@@ -58,8 +59,10 @@ function! s:apply_openbrowser(path) abort
 endfunction
 
 function! previm#refresh() abort
-  call previm#refresh_css()
-  call previm#refresh_js()
+  if exists('b:opened')
+    call previm#refresh_css()
+    call previm#refresh_js()
+  endif
 endfunction
 
 let s:default_origin_css_path = "@import url('../../_/css/origin.css');"


### PR DESCRIPTION
Suggested partial fix for #159 - do not generate/refresh a preview unless user has asked to see it at least once (i.e. opened the browser). This will cut down on number of files in the preview cache considerably.