### PR TITLE
[Feature] Support Mermaid.js file (`*.mmd`)

### DIFF
--- a/plugin/previm.vim
+++ b/plugin/previm.vim
@@ -28,7 +28,7 @@ endfunction
 
 augroup Previm
   autocmd!
-  autocmd FileType *{mkd,markdown,rst,textile,asciidoc}* call <SID>install_previm()
+  autocmd FileType *{mkd,markdown,mmd,mermaid,rst,textile,asciidoc}* call <SID>install_previm()
 augroup END
 
 let &cpo = s:save_cpo

--- a/preview/_/js/previm.js
+++ b/preview/_/js/previm.js
@@ -24,7 +24,6 @@
 
   function transform(filetype, content) {
     if(hasTargetFileType(filetype, ['mermaid', 'mmd'])) {
-
       content = '```mermaid\n'
               + content.replace(/</g, '&lt;')
                        .replace(/>/g, '&gt;')

--- a/preview/_/js/previm.js
+++ b/preview/_/js/previm.js
@@ -24,7 +24,11 @@
 
   function transform(filetype, content) {
     if(hasTargetFileType(filetype, ['mermaid', 'mmd'])) {
-      content = '```mermaid\n' + content + '\n```';
+
+      content = '```mermaid\n'
+              + content.replace(/</g, '&lt;')
+                       .replace(/>/g, '&gt;')
+              + '\n```';
       filetype = 'markdown';
     }
 

--- a/preview/_/js/previm.js
+++ b/preview/_/js/previm.js
@@ -23,6 +23,11 @@
   };
 
   function transform(filetype, content) {
+    if(hasTargetFileType(filetype, ['mermaid', 'mmd'])) {
+      content = '```mermaid\n' + content + '\n```';
+      filetype = 'markdown';
+    }
+
     if(hasTargetFileType(filetype, ['markdown', 'mkd'])) {
       return md.render(content);
     } else if(hasTargetFileType(filetype, ['rst'])) {


### PR DESCRIPTION
Fix for #165: support `mermaid` or `mmd` file type.

Just add Markdown code fence ` ```mermaid ... ``` ` to whole file content, and render as a Markdown file.