### PR TITLE
Mermaid.js Too Big Top / Bottom Margin

### DIFF
--- a/preview/_/js/previm.js
+++ b/preview/_/js/previm.js
@@ -93,6 +93,21 @@
 
       mermaid.init();
 
+      // FIXME:
+      // By default, Mermaid.js graph sometimes gets too long top and bottom margin.
+      // This is first-aid for it.
+      //
+      // It looks setting `height` property for `<svg>` node of rendered Mermaid.js graphs,
+      // so remove the setting.
+      //
+      // This is perhaps the Mermaid.js bug <https://github.com/mermaid-js/mermaid/issues/1758>,
+      // though, setting `{ flowchart : { useMaxWidth : false }}` anyhow makes the problem worse:
+      // it expands too widely.
+      Array.prototype.forEach.call(
+        _doc.querySelectorAll('.mermaid > svg')
+      , (mermaidImage) => mermaidImage.removeAttribute('height')
+      );
+
       loadPlantUML();
 
       Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), hljs.highlightBlock);


### PR DESCRIPTION
Mermaid.js graph sometimes get too wide top / bottom margin,
especially the graph is wide horizontally.

To fix it, removed `height` property of Mermaid.js graph `<svg>` node.

### Sample

~~~markdown
----

```mermaid
%%{ init : { "theme" : "default" }}%%

sequenceDiagram

%%==============================================================================

A ->> B : message
B ->> C : message
C ->> D : message
D ->> E : message
E ->> F : message
F ->> G : message
G ->> H : message
H ->> I : message

```

----
~~~

![Current](https://user-images.githubusercontent.com/31273423/152121474-bc61cae4-21d0-497f-b6b9-71ca1a133a2d.png)

### Fixed

![Fixed](https://user-images.githubusercontent.com/31273423/152121499-d1d366eb-52c0-45af-90c4-4061b99d2c93.png)

----

Perhaps this comes from [Mermaid.js bug](https://github.com/mermaid-js/mermaid/issues/1758), though,  
setting `{ sequence : { useMaxWidth : false }}` was not fine:
Mermaid.js graph got too wide.

So, as first-aid, removed `<svg>` `height` property for now.