### PR TITLE
Added plantuml file preview feature

### DIFF
--- a/plugin/previm.vim
+++ b/plugin/previm.vim
@@ -28,7 +28,7 @@ endfunction
 
 augroup Previm
   autocmd!
-  autocmd FileType *{mkd,markdown,rst,textile,asciidoc}* call <SID>install_previm()
+  autocmd FileType *{mkd,markdown,rst,textile,asciidoc,plantuml}* call <SID>install_previm()
 augroup END
 
 let &cpo = s:save_cpo

--- a/preview/_/js/previm.js
+++ b/preview/_/js/previm.js
@@ -25,6 +25,9 @@
   function transform(filetype, content) {
     if(hasTargetFileType(filetype, ['markdown', 'mkd'])) {
       return md.render(content);
+    } else if(hasTargetFileType(filetype, ['plantuml'])) {
+      content = "```plantuml\n" + content + "```";
+      return md.render(content);
     } else if(hasTargetFileType(filetype, ['rst'])) {
       // It has already been converted by rst2html.py
       return content;


### PR DESCRIPTION
Added plantuml filetype (`*.puml`) preview functionality in an easy-lazy way.
(It might need to install https://github.com/aklt/plantuml-syntax to make vim recognize plantuml filetype.)

If it's okay I will do the documents also if it's needed.