### PR TITLE
[Bugfix] Hard-line-break option (`g:previm_hard_line_break`)

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -413,7 +413,7 @@ function! previm#options()
   endif
   return json_encode({
   \   'imagePrefix': get(g:, 'previm_plantuml_imageprefix', v:null),
-  \   'hardLineBreak': get(g:, 'previm_hard_line_break', v:false),
+  \   'hardLineBreak': get(b:, 'previm_hard_line_break', get(g:, 'previm_hard_line_break', v:false)),
   \   'showheader': get(g:, 'previm_show_header', 1),
   \   'autoClose': get(g:, 'previm_auto_close', 0),
   \ })

--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -413,7 +413,7 @@ function! previm#options()
   endif
   return json_encode({
   \   'imagePrefix': get(g:, 'previm_plantuml_imageprefix', v:null),
-  \   'hardLineBreak': get(g:, 'previm_hard_line_break', v:false) ? 'true' : 'false',
+  \   'hardLineBreak': get(g:, 'previm_hard_line_break', v:false),
   \   'showheader': get(g:, 'previm_show_header', 1),
   \   'autoClose': get(g:, 'previm_auto_close', 0),
   \ })


### PR DESCRIPTION
Fix for https://github.com/previm/previm/issues/174.

Along with it, re-enabled buffer-wise setting `b:previm_hard_line_break`.
If you think it should not be, revert the latter commit 008f5f7.
