### PR TITLE
Handle Local Link

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -371,21 +371,21 @@ function! previm#relative_to_absolute_filepath(text, mkd_dir) abort
   endif
   if elem.type == 'label'
     if empty(elem.title)
-      let prev_filepath = printf(                                  '\[%s\]:\s*%s'      , elem.alt , elem.path)
-      let new_filepath  = printf(                                  '[%s]: %s%s%s'      , elem.alt , path_prefix , pre_slash , local_path)
+      let prev_filepath = printf(                                  '\[%s\]:\s*%s'         , elem.alt , elem.path)
+      let new_filepath  = printf(                                  '[%s]: %s%s%s'         , elem.alt , path_prefix , pre_slash , local_path)
     else
-      let prev_filepath = printf(                                  '\[%s\]:\s*%s "%s"' , elem.alt , elem.path   , elem.title)
-      let new_filepath  = printf(                                  '[%s]: %s%s%s "%s"' , elem.alt , path_prefix , pre_slash , local_path , elem.title)
+      let prev_filepath = printf(                                  '\[%s\]:\s*%s\s\+"%s"' , elem.alt , elem.path   , elem.title)
+      let new_filepath  = printf(                                  '[%s]: %s%s%s "%s"'    , elem.alt , path_prefix , pre_slash , local_path , elem.title)
     endif
   else
     let new_alt = previm#convert_relative_to_absolute_filepath(elem.alt, a:mkd_dir)
 
     if empty(elem.title)
-      let prev_filepath = printf((elem.type == 'img' ? '!' : '') . '\V[%s](%s)'        , elem.alt , elem.path)
-      let new_filepath  = printf((elem.type == 'img' ? '!' : '') . '[%s](%s%s%s)'      , new_alt  , path_prefix , pre_slash , local_path)
+      let prev_filepath = printf((elem.type == 'img' ? '!' : '') . '\V[%s](%s)'          , elem.alt , elem.path)
+      let new_filepath  = printf((elem.type == 'img' ? '!' : '') . '[%s](%s%s%s)'        , new_alt  , path_prefix , pre_slash , local_path)
     else
-      let prev_filepath = printf((elem.type == 'img' ? '!' : '') . '\V[%s\](%s "%s")'  , elem.alt , elem.path   , elem.title)
-      let new_filepath  = printf((elem.type == 'img' ? '!' : '') . '[%s](%s%s%s "%s")' , new_alt  , path_prefix , pre_slash , local_path , elem.title)
+      let prev_filepath = printf((elem.type == 'img' ? '!' : '') . '\V[%s\](%s\s\+"%s")' , elem.alt , elem.path   , elem.title)
+      let new_filepath  = printf((elem.type == 'img' ? '!' : '') . '[%s](%s%s%s "%s")'   , new_alt  , path_prefix , pre_slash , local_path , elem.title)
     endif
   endif
 

--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -315,7 +315,7 @@ function! previm#convert_to_content(lines) abort
   for line in s:do_external_parse(a:lines)
     " TODO エスケープの理由と順番の依存度が複雑
     let escaped = substitute(line, '\', '\\\\', 'g')
-    let escaped = previm#convert_relative_to_absolute_imgpath(escaped, mkd_dir)
+    let escaped = previm#convert_relative_to_absolute_filepath(escaped, mkd_dir)
     let escaped = substitute(escaped, '"', '\\"', 'g')
     let escaped = substitute(escaped, '\r', '\\r', 'g')
     call add(converted_lines, escaped)
@@ -323,8 +323,8 @@ function! previm#convert_to_content(lines) abort
   return join(converted_lines, "\\n")
 endfunction
 
-function! previm#convert_relative_to_absolute_imgpath(text, mkd_dir) abort
-  return substitute(a:text, '!\[[^\]]*\]([^)]*)', '\=previm#relative_to_absolute_imgpath(submatch(0), a:mkd_dir)', 'g')
+function! previm#convert_relative_to_absolute_filepath(text, mkd_dir) abort
+  return substitute(a:text, '!\?\[[^\]]*\]([^)]*)', '\=previm#relative_to_absolute_filepath(submatch(0), a:mkd_dir)', 'g')
 endfunction
 
 " convert example
@@ -332,8 +332,8 @@ endfunction
 "   ![alt](file://localhost/Users/kanno/Pictures/img.png "title")
 " if win:
 "   ![alt](file://localhost/C:\Documents%20and%20Settings\folder/pictures\img.png "title")
-function! previm#relative_to_absolute_imgpath(text, mkd_dir) abort
-  let elem = previm#fetch_imgpath_elements(a:text)
+function! previm#relative_to_absolute_filepath(text, mkd_dir) abort
+  let elem = previm#fetch_filepath_elements(a:text)
   if empty(elem.path)
     return a:text
   endif
@@ -359,8 +359,8 @@ function! previm#relative_to_absolute_imgpath(text, mkd_dir) abort
     let local_path = substitute(dir.'/'.elem.path, ' ', '%20', 'g')
   endif
 
-  let prev_imgpath = ''
-  let new_imgpath = ''
+  let prev_filepath = ''
+  let new_filepath = ''
   let path_prefix = '//localhost'
   if get(g:, 'previm_wsl_mode', 0) ==# 1
     let path_prefix = ''
@@ -370,26 +370,29 @@ function! previm#relative_to_absolute_imgpath(text, mkd_dir) abort
     let local_path = local_path[7:]
   endif
   if empty(elem.title)
-    let prev_imgpath = printf('!\[%s\](%s)', elem.alt, elem.path)
-    let new_imgpath = printf('![%s](%s%s%s)', elem.alt, path_prefix, pre_slash, local_path)
+    let prev_filepath = printf((elem.type == 'img' ? '!' : '') . '\[%s\](%s)'        , elem.alt , elem.path)
+    let new_filepath  = printf((elem.type == 'img' ? '!' : '') . '[%s](%s%s%s)'      , elem.alt , path_prefix , pre_slash , local_path)
   else
-    let prev_imgpath = printf('!\[%s\](%s "%s")', elem.alt, elem.path, elem.title)
-    let new_imgpath = printf('![%s](%s%s%s "%s")', elem.alt, path_prefix, pre_slash, local_path, elem.title)
+    let prev_filepath = printf((elem.type == 'img' ? '!' : '') . '\[%s\](%s "%s")'   , elem.alt , elem.path   , elem.title)
+    let new_filepath  = printf((elem.type == 'img' ? '!' : '') . '[%s](%s%s%s "%s")' , elem.alt , path_prefix , pre_slash , local_path , elem.title)
   endif
 
   " unify quote
   let text = substitute(a:text, "'", '"', 'g')
-  return substitute(text, prev_imgpath, new_imgpath, '')
+  return substitute(text, prev_filepath, new_filepath, '')
 endfunction
 
-function! previm#fetch_imgpath_elements(text) abort
-  let elem = {'alt': '', 'path': '', 'title': ''}
-  let matched = matchlist(a:text, '!\[\([^\]]*\)\](\([^)]*\))')
+function! previm#fetch_filepath_elements(text) abort
+  let elem = {'type': '', 'alt': '', 'path': '', 'title': ''}
+
+  let matched = matchlist(a:text, '\(!\?\)\[\([^\]]*\)\](\([^)]*\))')
   if empty(matched)
     return elem
   endif
-  let elem.alt = matched[1]
-  return extend(elem, s:fetch_path_and_title(matched[2]))
+
+  let elem.type = matched[1] ==# '!' ? 'img' : 'link'
+  let elem.alt = matched[2]
+  return extend(elem, s:fetch_path_and_title(matched[3]))
 endfunction
 
 function! s:fetch_path_and_title(path) abort

--- a/test/autoload/previm_test.vim
+++ b/test/autoload/previm_test.vim
@@ -40,31 +40,31 @@ let s:t = themis#suite('relative_to_absolute') "{{{
 function! s:t.nothing_when_empty()
   let arg_line = ''
   let expected = ''
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, ''), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, ''), expected)
 endfunction
 
 function! s:t.nothing_when_not_href()
   let arg_line = 'previm.dummy.com/some/path/img.png'
   let expected = 'previm.dummy.com/some/path/img.png'
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, ''), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, ''), expected)
 endfunction
 
 function! s:t.nothing_when_absolute_by_http()
   let arg_line = 'http://previm.dummy.com/some/path/img.png'
   let expected = 'http://previm.dummy.com/some/path/img.png'
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, ''), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, ''), expected)
 endfunction
 
 function! s:t.nothing_when_absolute_by_https()
   let arg_line = 'https://previm.dummy.com/some/path/img.png'
   let expected = 'https://previm.dummy.com/some/path/img.png'
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, ''), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, ''), expected)
 endfunction
 
 function! s:t.nothing_when_absolute_by_file()
   let arg_line = 'file://previm/some/path/img.png'
   let expected = 'file://previm/some/path/img.png'
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, ''), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, ''), expected)
 endfunction
 
 function! s:t.replace_path_when_relative()
@@ -72,7 +72,7 @@ function! s:t.replace_path_when_relative()
   let arg_line = printf('![img](%s)', rel_path)
   let arg_dir = '/Users/foo/tmp'
   let expected = printf('![img](//localhost%s/%s)', arg_dir, rel_path)
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, arg_dir), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, arg_dir), expected)
 endfunction
 
 function! s:t.urlencoded_path()
@@ -80,7 +80,7 @@ function! s:t.urlencoded_path()
   let arg_line = printf('![img](%s)', rel_path)
   let arg_dir = 'C:\Documents and Settings\folder'
   let expected = '![img](//localhost/C:\Documents%20and%20Settings\folder/previm\some\path\img.png)'
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, arg_dir), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, arg_dir), expected)
 endfunction
 
 function! s:t.with_title_from_double_quote()
@@ -88,7 +88,7 @@ function! s:t.with_title_from_double_quote()
   let arg_line = printf('![img](%s "title")', rel_path)
   let arg_dir = 'C:\Documents and Settings\folder'
   let expected = '![img](//localhost/C:\Documents%20and%20Settings\folder/previm\some\path\img.png "title")'
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, arg_dir), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, arg_dir), expected)
 endfunction
 
 function! s:t.with_title_from_single_quote()
@@ -96,7 +96,7 @@ function! s:t.with_title_from_single_quote()
   let arg_line = printf("![img](%s 'title')", rel_path)
   let arg_dir = 'C:\Documents and Settings\folder'
   let expected = '![img](//localhost/C:\Documents%20and%20Settings\folder/previm\some\path\img.png "title")'
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, arg_dir), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, arg_dir), expected)
 endfunction
 
 function! s:t.not_only_img()
@@ -104,49 +104,49 @@ function! s:t.not_only_img()
   let arg_line = printf('| a | ![img](%s) |', rel_path)
   let arg_dir  = '/Users/foo/tmp'
   let expected = printf('| a | ![img](//localhost%s/%s) |', arg_dir, rel_path)
-  call s:assert.equals(previm#relative_to_absolute_imgpath(arg_line, arg_dir), expected)
+  call s:assert.equals(previm#relative_to_absolute_filepath(arg_line, arg_dir), expected)
 endfunction
 "}}}
-let s:t = themis#suite('fetch_imgpath_elements') "{{{
+let s:t = themis#suite('fetch_filepath_elements') "{{{
 
 function! s:t.nothing_when_empty()
   let arg = ''
   let expected = s:empty_img_elements()
-  call s:assert.equals(previm#fetch_imgpath_elements(arg), expected)
+  call s:assert.equals(previm#fetch_filepath_elements(arg), expected)
 endfunction
 
 function! s:t.nothing_when_not_img_statement()
   let arg = '## hogeほげ'
   let expected = s:empty_img_elements()
-  call s:assert.equals(previm#fetch_imgpath_elements(arg), expected)
+  call s:assert.equals(previm#fetch_filepath_elements(arg), expected)
 endfunction
 
 function! s:t.get_alt_and_path()
   let arg = '![IMG](path/img.png)'
-  let expected = {'alt': 'IMG', 'path': 'path/img.png', 'title': ''}
-  call s:assert.equals(previm#fetch_imgpath_elements(arg), expected)
+  let expected = {'type': 'img', 'alt': 'IMG', 'path': 'path/img.png', 'title': ''}
+  call s:assert.equals(previm#fetch_filepath_elements(arg), expected)
 endfunction
 
 function! s:t.get_alt_and_path_from_image_in_link()
   let arg = '[![IMG](path/img.png)](path/some/file)'
-  let expected = {'alt': 'IMG', 'path': 'path/img.png', 'title': ''}
-  call s:assert.equals(previm#fetch_imgpath_elements(arg), expected)
+  let expected = {'type': 'img', 'alt': 'IMG', 'path': 'path/img.png', 'title': ''}
+  call s:assert.equals(previm#fetch_filepath_elements(arg), expected)
 endfunction
 
 function! s:t.get_title_from_double_quote()
   let arg = '![IMG](path/img.png  "image")'
-  let expected = {'alt': 'IMG', 'path': 'path/img.png', 'title': 'image'}
-  call s:assert.equals(expected, previm#fetch_imgpath_elements(arg))
+  let expected = {'type': 'img', 'alt': 'IMG', 'path': 'path/img.png', 'title': 'image'}
+  call s:assert.equals(expected, previm#fetch_filepath_elements(arg))
 endfunction
 
 function! s:t.get_title_from_single_quote()
   let arg = "![IMG](path/img.png  'image')"
-  let expected = {'alt': 'IMG', 'path': 'path/img.png', 'title': 'image'}
-  call s:assert.equals(expected, previm#fetch_imgpath_elements(arg))
+  let expected = {'type': 'img', 'alt': 'IMG', 'path': 'path/img.png', 'title': 'image'}
+  call s:assert.equals(expected, previm#fetch_filepath_elements(arg))
 endfunction
 
 function! s:empty_img_elements()
-  return {'alt': '', 'path': '', 'title': ''}
+  return {'type': '', 'alt': '', 'path': '', 'title': ''}
 endfunction
 "}}}
 let s:t = themis#suite('refresh_css') "{{{

--- a/test/autoload/previm_test.vim
+++ b/test/autoload/previm_test.vim
@@ -129,8 +129,12 @@ endfunction
 
 function! s:t.get_alt_and_path_from_image_in_link()
   let arg = '[![IMG](path/img.png)](path/some/file)'
-  let expected = {'type': 'img', 'alt': 'IMG', 'path': 'path/img.png', 'title': ''}
-  call s:assert.equals(previm#fetch_filepath_elements(arg), expected)
+  let expected1 = {'type': 'link', 'alt': '![IMG](path/img.png)', 'path': 'path/some/file', 'title': ''}
+  let expected2 = {'type': 'img', 'alt': 'IMG', 'path': 'path/img.png', 'title': ''}
+  let ret1 = previm#fetch_filepath_elements(arg)
+  let ret2 = previm#fetch_filepath_elements(ret1.alt)
+  call s:assert.equals(ret1, expected1)
+  call s:assert.equals(ret2, expected2)
 endfunction
 
 function! s:t.get_title_from_double_quote()


### PR DESCRIPTION
Support local link along with local image reference.

Now it only supports local image (e.g. `![ALT_TEXT](local/image/path.png)`).

Along with this, make it support local link (e.g. `[LINK_TEXT](local/file/path.txt)`, the syntax not `!`-preceding).

Also, handle local link label (e.g. `[LABEL]: local/file/path.txt`).
This syntax is used for both of link (`[LINK_TEXT][LABEL]`) and image (`![ALT_TEXT][LABEL]`).

Constraints:
Of course, local link for markdown is opened as raw text without rich-styling.
