### PR TITLE
Support for language display of code blocks

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -442,7 +442,7 @@ function! previm#options()
   \   'showheader': get(g:, 'previm_show_header', 1),
   \   'autoClose': get(g:, 'previm_auto_close', 0),
   \   'showCodeLanguage': get(g:, 'previm_code_language_show', 0),
-  \   'codeLanguageSeparator': get(g:, 'previm_code_language_separator', '[\s|:]+'),
+  \   'codeLanguageSeparator': get(g:, 'previm_code_language_separator', '[\s:]+'),
   \ })
 endfunction
 

--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -441,6 +441,8 @@ function! previm#options()
   \   'hardLineBreak': get(b:, 'previm_hard_line_break', get(g:, 'previm_hard_line_break', v:false)),
   \   'showheader': get(g:, 'previm_show_header', 1),
   \   'autoClose': get(g:, 'previm_auto_close', 0),
+  \   'showCodeLanguage': get(g:, 'previm_code_language_show', 0),
+  \   'codeLanguageSeparator': get(g:, 'previm_code_language_separator', '[\s|:]+'),
   \ })
 endfunction
 

--- a/doc/previm.jax
+++ b/doc/previm.jax
@@ -1,6 +1,6 @@
 *previm.txt*	プレビュー用プラグイン
 
-Version: 1.6
+Version: 2.0
 Author: kanno <akapanna@gmail.com>
 Maintainer: previm developers
 
@@ -179,6 +179,47 @@ g:previm_hard_line_break			*g:previm_hard_line_break*
 	" .vimrc
 	let g:previm_hard_line_break = 1
 
+g:previm_code_language_show			*g:previm_code_language_show*
+	型:数値
+
+	プレビュー時のコードブロックの言語(もしくは、ファイル名)表示機能を設定します。
+
+	値が1ならば、コードブロックの言語表示機能を使用します。
+	値が0ならば、コードブロックの言語表示機能を使用しません。
+	デフォルトでは0に設定されています。
+
+	ハイライト言語のみ指定する場合
+>
+	```language
+	Hello world
+	```
+<
+	ハイライト言語指定と表示ファイル名を分けて表示する場合(スペース区切り)
+>
+	```language filename.ext
+	Hello world
+	```
+<
+	ハイライト言語指定と表示ファイル名を分けて表示する場合(コロン区切り)
+>
+	```language:filename.ext
+	Hello world
+	```
+
+	" .vimrc
+	let g:previm_code_language_show = 1
+
+g:previm_code_language_separator		*g:previm_code_language_separator*
+	型:文字列
+
+	g:previm_code_language_show を使用した際の言語とファイル名の区切り文字
+	を設定します。(JavaScriptの正規表現仕様)
+
+	デフォルトでは'[\s|:]+'に設定されています。
+>
+	" .vimrc
+	let g:previm_code_language_separator = '[\s|:]+'
+
 ==============================================================================
 追加ライブラリの利用					*previm-extralibraries*
 
@@ -222,6 +263,9 @@ open-browser.vimの使用					*previm-openbrowser*
 
 ==============================================================================
 更新履歴						*previm-changelog*
+
+2.0  	2023-09-20
+        - support for language display of code blocks
 
 1.9  	2022-06-14
         - support adding extra libraries

--- a/doc/previm.jax
+++ b/doc/previm.jax
@@ -215,10 +215,10 @@ g:previm_code_language_separator		*g:previm_code_language_separator*
 	g:previm_code_language_show を使用した際の言語とファイル名の区切り文字
 	を設定します。(JavaScriptの正規表現仕様)
 
-	デフォルトでは'[\s|:]+'に設定されています。
+	デフォルトでは'[\s:]+'に設定されています。
 >
 	" .vimrc
-	let g:previm_code_language_separator = '[\s|:]+'
+	let g:previm_code_language_separator = '[\s:]+'
 
 ==============================================================================
 追加ライブラリの利用					*previm-extralibraries*

--- a/doc/previm.txt
+++ b/doc/previm.txt
@@ -1,6 +1,6 @@
 *previm.txt*	Preview Plugin
 
-Version: 1.8.1
+Version: 2.0
 Author: kanno <akapanna@gmail.com>
 Maintainer: previm developers
 
@@ -192,6 +192,52 @@ g:previm_hard_line_break			*g:previm_hard_line_break*
 	" .vimrc
 	let g:previm_hard_line_break = 1
 
+g:previm_code_language_show			*g:previm_code_language_show*
+	Type:Num
+
+	Sets the ability to display the language (or file name) of the code
+	block during preview.
+
+	If the value is 1, use the language display function of the code block.
+	If the value is 0, the language display feature of the code block 
+	is not used.
+	It is set to 0 by default.
+
+	To specify only the highlighted language
+>
+	```language
+	Hello world
+	```
+<
+	Separate highlight language specification and display file name
+	(separated by a space)
+>
+	```language filename.ext
+	Hello world
+	```
+<
+	Separate highlight language specification and display file name
+	(separated by a colon)
+>
+	```language:filename.ext
+	Hello world
+	```
+
+	" .vimrc
+	let g:previm_code_language_show = 1
+
+g:previm_code_language_separator		*g:previm_code_language_separator*
+	Type:String
+
+	Sets the language and filename separator when using
+	g:previm_code_language_show. (JavaScript RegExp specification)
+
+	By default, it is set to '[\s|:]+'.
+>
+	" .vimrc
+	let g:previm_code_language_separator = '[\s|:]+'
+
+
 ==============================================================================
 USING EXTRA LIBRARIES					*previm-extralibraries*
 
@@ -235,6 +281,9 @@ Thus, |g:previm_open_cmd| need not be configured when using open-browser.vim.
 
 ==============================================================================
 CHANGELOG						*previm-changelog*
+
+2.0  	2023-09-20
+        - support for language display of code blocks
 
 1.9  	2022-06-14
         - support adding extra libraries

--- a/doc/previm.txt
+++ b/doc/previm.txt
@@ -232,10 +232,10 @@ g:previm_code_language_separator		*g:previm_code_language_separator*
 	Sets the language and filename separator when using
 	g:previm_code_language_show. (JavaScript RegExp specification)
 
-	By default, it is set to '[\s|:]+'.
+	By default, it is set to '[\s:]+'.
 >
 	" .vimrc
-	let g:previm_code_language_separator = '[\s|:]+'
+	let g:previm_code_language_separator = '[\s:]+'
 
 
 ==============================================================================

--- a/preview/_/css/origin.css
+++ b/preview/_/css/origin.css
@@ -109,6 +109,7 @@ pre code
   background: transparent;
   margin: 0;
   padding: 0;
+  display: block;
 }
 
 a, a code {
@@ -228,4 +229,14 @@ input[type="checkbox"] + label {
   table, pre {
     page-break-inside: avoid;
   }
+}
+
+.code-lang {
+  color: #eee;
+  display: inline-block;
+  background-color: #777;
+  padding: 2px 4px;
+  transform: translateY(-1em);
+  word-break: break-all;
+  margin-top: 6px;
 }

--- a/preview/_/js/previm.js.tmpl
+++ b/preview/_/js/previm.js.tmpl
@@ -172,7 +172,7 @@
       if (getOptions().showCodeLanguage === 1) {
           Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), function (item, index) {
             var fileName = item.getAttribute('code-lang');
-            if (fileName !== '') {
+            if (fileName) {
               var codeLang = _doc.createElement('div');
               codeLang.setAttribute('class','code-lang');
               codeLang.innerHTML = '<span class="bold">' + fileName + '</span>';

--- a/preview/_/js/previm.js.tmpl
+++ b/preview/_/js/previm.js.tmpl
@@ -170,17 +170,17 @@
 
       // Settings code-lang
       if (getOptions().showCodeLanguage === 1) {
-          Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), function (item, index) {
-            var fileName = item.getAttribute('code-lang');
-            if (fileName) {
-              var codeLang = _doc.createElement('div');
-              codeLang.setAttribute('class','code-lang');
-              codeLang.innerHTML = '<span class="bold">' + fileName + '</span>';
-              item.parentNode.insertBefore(codeLang, item);
-            }
-          });
+        Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), function (item, index) {
+          var fileName = item.getAttribute('code-lang');
+          if (fileName) {
+            var codeLang = _doc.createElement('div');
+            codeLang.setAttribute('class','code-lang');
+            codeLang.innerHTML = '<span class="bold">' + fileName + '</span>';
+            item.parentNode.insertBefore(codeLang, item.parentNode.firstElementChild);
+          }
+        });
       }
-      Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), hljs.highlightElement);
+      Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), hljs.highlightBlock);
       autoScroll('body', beforePageYOffset);
       style_header();
     }

--- a/preview/_/js/previm.js.tmpl
+++ b/preview/_/js/previm.js.tmpl
@@ -43,6 +43,18 @@
     if (langName === 'mermaid') {
       return '<div class="mermaid">' + token.content + '</div>';
     }
+    // Settings code-lang 
+    var sep = new RegExp(getOptions().codeLanguageSeparator);
+    var tokenSplit = token.info.trim().split(sep);
+    var langName = tokenSplit[0];
+    var fileName = '';
+    if (tokenSplit.length > 1) {
+        fileName = tokenSplit.slice(1).join(' ');
+    } else {
+        fileName = langName;
+    }
+    tokens[idx].attrPush(['code-lang', fileName]);
+
     return original_fence(tokens, idx, options, env, slf);
   };
 
@@ -156,6 +168,18 @@
 
       loadPlantUML();
 
+      // Settings code-lang
+      if (getOptions().showCodeLanguage === 1) {
+          Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), function (item, index) {
+            var fileName = item.getAttribute('code-lang');
+            if (fileName !== '') {
+              var codeLang = _doc.createElement('div');
+              codeLang.setAttribute('class','code-lang');
+              codeLang.innerHTML = '<span class="bold">' + fileName + '</span>';
+              item.parentNode.insertBefore(codeLang, item);
+            }
+          });
+      }
       Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), hljs.highlightBlock);
       autoScroll('body', beforePageYOffset);
       style_header();

--- a/preview/_/js/previm.js.tmpl
+++ b/preview/_/js/previm.js.tmpl
@@ -180,7 +180,7 @@
           }
         });
       }
-      Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), hljs.highlightBlock);
+      Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), hljs.highlightElement);
       autoScroll('body', beforePageYOffset);
       style_header();
     }

--- a/preview/_/js/previm.js.tmpl
+++ b/preview/_/js/previm.js.tmpl
@@ -180,7 +180,7 @@
             }
           });
       }
-      Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), hljs.highlightBlock);
+      Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), hljs.highlightElement);
       autoScroll('body', beforePageYOffset);
       style_header();
     }


### PR DESCRIPTION
Added highlighting of the following code blocks.

- Normal code blocks

````markdown
```ruby
puts 'The best way to log and share programmers knowledge.'
```
````

- Qiita, Zenn style (Separetor by a coron)

````markdown
```ruby:qiita.rb
puts 'The best way to log and share programmers knowledge.'
```
````

- VSCode, Vim style (Separetor by a space)

````markdown
```apache /etc/apache/conf.d/conf/foo.conf
ServerTokens Major
# aaa
Listen 80
```
````

![codeblocks](https://github.com/previm/previm/assets/790009/4fa33af8-e5cd-4460-8960-c7d548065b76)

## Refs

- [Markdown記法 チートシート - Qiita](https://qiita.com/Qiita/items/c686397e4a0f4f11683d#code---%E3%82%B3%E3%83%BC%E3%83%89%E3%81%AE%E6%8C%BF%E5%85%A5)
- [ZennのMarkdown記法一覧](https://zenn.dev/zenn/articles/markdown-guide#%E3%82%B3%E3%83%BC%E3%83%89%E3%83%96%E3%83%AD%E3%83%83%E3%82%AF)
