### PR TITLE
Isn't backslash (`\`) escape too much?

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -314,7 +314,7 @@ function! previm#convert_to_content(lines) abort
   let converted_lines = []
   for line in s:do_external_parse(a:lines)
     " TODO エスケープの理由と順番の依存度が複雑
-    let escaped = substitute(line, '\', '\\\\', 'g')
+    let escaped = substitute(line, '\', '\\', 'g')
     let escaped = previm#convert_relative_to_absolute_filepath(escaped, mkd_dir)
     let escaped = substitute(escaped, '"', '\\"', 'g')
     let escaped = substitute(escaped, '\r', '\\r', 'g')


### PR DESCRIPTION
In writing backslash (`/`), it is rendered as `//`.
Isn't it escaping too much?

Also, due to this, Mermaid graph using `/` may get syntax errors.

```text
flowchart LR

NodeSS[/" Node [/ /] "/]
NodeBB[\" Node [\\ \\] "\]
NodeSB[/" Node [/ \\] "\]
NodeBS[\" Node [\ /] "/]
Node["Node [\a] "]
```

* [LiveEditor](https://mermaid.live/edit#pako:eNplUM0KgzAMfpWSs9C7x7Ldth3W24yHYOsPaDu6ljHEd1_UKcgu4cv3k4SMUHljIYe69--qpRDF5Y4O3Y1prQuJIGYoCilkKRBkuWpKFYi7yBDFXGYL119eHfJ_utLHGccNBcIm0MyXkMFgw0Cd4XtHdILJ2NrBIuQMja0p9ZHnu4mt6Wko2rPpog-Qx5BsBpSi1x9Xbf3qOXXUBBogr6l_MWuXzHX9y_KeDIJPTbs7nuQe3m-J6QuTCGrr)

----

However, BTW, GitHub gets syntax errors for the Mermaid graph above.
Character escape is too complicated issue, huh?

```mermaid
flowchart LR

NodeSS[/" Node [/ /] "/]
NodeBB[\" Node [\\ \\] "\]
NodeSB[/" Node [/ \\] "\]
NodeBS[\" Node [\ /] "/]
Node["Node [\a] "]
```
