### PR TITLE
Revert "Escape text prior to convert path"

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -324,17 +324,7 @@ function! previm#convert_to_content(lines) abort
 endfunction
 
 function! previm#convert_relative_to_absolute_filepath(text, mkd_dir) abort
-  return substitute(
-        \ s:escape_pattern(a:text),
-        \ '\v!?\[%([^\[\]\(\)]+|\[[^\[\]]*\]|\([^()]*\))*\]\([^()]*\)|^\[([^\[\]]*)\]:\s*(.*)',
-        \ '\=previm#relative_to_absolute_filepath(submatch(0), a:mkd_dir)',
-        \ 'g',
-        \)
-endfunction
-
-function! s:escape_pattern(str) abort
-  " escape characters for no-magic
-  return escape(a:str, '^$~.*[]\')
+  return substitute(a:text, '\v!?\[%([^\[\]\(\)]+|\[[^\[\]]*\]|\([^()]*\))*\]\([^()]*\)|^\[([^\[\]]*)\]:\s*(.*)', '\=previm#relative_to_absolute_filepath(submatch(0), a:mkd_dir)', 'g')
 endfunction
 
 " convert example


### PR DESCRIPTION
Reverts previm/previm#208

This commit caused #212 and test failure.