### PR TITLE
feat: use HTTPS for PlantUML server

### DIFF
--- a/doc/previm.jax
+++ b/doc/previm.jax
@@ -158,7 +158,7 @@ g:previm_plantuml_imageprefix			*g:previm_plantuml_imageprefix*
 
 	plantuml をローカルサーバで使用する場合のエンドポイントを指定します。
 
-	未指定の場合は http://plantuml.com/plantuml/img/ が使われます。
+	未指定の場合は https://plantuml.com/plantuml/img/ が使われます。
 
 >
 	" .vimrc

--- a/doc/previm.txt
+++ b/doc/previm.txt
@@ -169,7 +169,7 @@ g:previm_plantuml_imageprefix			*g:previm_plantuml_imageprefix*
 
 	Specify endpoint of plantuml server if you want to use it in local.
 
-	If the value is not specified, http://plantuml.com/plantuml/img/ is
+	If the value is not specified, https://plantuml.com/plantuml/img/ is
 	used.
 
 >

--- a/preview/_/js/lib/plantuml.js
+++ b/preview/_/js/lib/plantuml.js
@@ -54,7 +54,7 @@ function compress(prefix, a) {
   if (prefix) {
     return prefix + encode64(zip_deflate(a, 9));
   }
-  return "http://plantuml.com/plantuml/img/" + encode64(zip_deflate(a, 9));
+  return "https://plantuml.com/plantuml/img/" + encode64(zip_deflate(a, 9));
 }
 
 function loadPlantUML() {


### PR DESCRIPTION
PlantUML server URL was using HTTP, changed it to HTTPS for security and compatibility.
HTTPS is more secure and recommended. This change does not affect functionality, only improves security.