### PR TITLE
Set `.code-lang-title` for filename specified code block

### DIFF
--- a/preview/_/js/previm.js.tmpl
+++ b/preview/_/js/previm.js.tmpl
@@ -49,7 +49,7 @@
     const codeLangName = tokenSplit[0];
     let fileName = '';
     if (tokenSplit.length > 1) {
-        fileName = tokenSplit.slice(1).join(' ');
+        fileName = `${tokenSplit[0]}:${tokenSplit.slice(1).join(' ')}`;
     } else {
         fileName = codeLangName;
     }
@@ -171,11 +171,11 @@
       // Settings code-lang
       if (getOptions().showCodeLanguage === 1) {
         Array.prototype.forEach.call(_doc.querySelectorAll('pre code'), function (item, index) {
-          const fileName = item.getAttribute('code-lang');
+          const fileName = item.getAttribute('code-lang')?.split(/:/);
           if (fileName) {
             const codeLang = _doc.createElement('div');
-            codeLang.setAttribute('class','code-lang');
-            codeLang.innerHTML = '<span class="bold">' + fileName + '</span>';
+            codeLang.setAttribute('class','code-lang' + (fileName.length <= 1 ? '' : ' code-lang-title'));
+            codeLang.innerHTML = '<span class="bold">' + fileName[fileName.length <= 1 ? 0 : 1] + '</span>';
             item.parentNode.insertBefore(codeLang, item.parentNode.firstElementChild);
           }
         });


### PR DESCRIPTION
For `g:previm_code_language_show`,
code block language ```` ```lang ```` and filename ```` ```lang:filename.txt ```` are both assigned to `div.code-lang`.
To show only filename-specified cases, shouldn't it be recognizable?

Added a class name `code-lang-title` for the cases of ```` ```lang:filename.txt ```` to hide language-only cases in css as below:

```css
.code-lang:not(.code-lang-title) {
    display : none;
}
```
