### PR TITLE
do not expand local paths in code block

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -312,6 +312,7 @@ function! previm#convert_to_content(lines) abort
     let mkd_dir = substitute(mkd_dir, '\', '/', 'g')
   endif
   let converted_lines = []
+  " コードブロック内ではパスの展開は行わない
   let in_codeblock = 0
   for line in s:do_external_parse(a:lines)
     if line =~ '^```'


### PR DESCRIPTION
Go's generics use the same syntax as Markdown links. Inside code blocks, it need to disable the conversion to local file paths.
```
func iter1[T any](a []T) iter.Seq[string] {
	return func(yield func(string) bool) {
		for _, v := range a {
			if !yield(fmt.Sprint(v)) {
				break
			}
		}
	}
}
```