### PR TITLE
Restore scroll position on browser page refresh

### DIFF
--- a/preview/_/js/previm.js.tmpl
+++ b/preview/_/js/previm.js.tmpl
@@ -234,6 +234,7 @@
     }
   }
 
+  let isFirstLoad = true;
   const interval = _win.setInterval(function() {
     const script = _doc.createElement('script');
 
@@ -255,7 +256,24 @@
 
     _doc.getElementsByTagName('head')[0].appendChild(script);
 
+    if (isFirstLoad) {
+      _addEventListener(script, 'load', function() {
+        if (/#scroll=(\d+),(\d+)$/.test(_win.location.href)) {
+          const x = parseInt(RegExp.$1, 10);
+          const y = parseInt(RegExp.$2, 10);
+          _win.setTimeout(function() {
+            _win.scrollTo(x, y);
+          }, 300);
+        }
+      });
+      isFirstLoad = false;
+    }
+
   }, REFRESH_INTERVAL);
+
+  _addEventListener(_doc, 'scrollend', function() {
+    _win.location.href = _win.location.href.replace(/(#.*)?$/, '#scroll=' + _win.scrollX + ',' + _win.scrollY);
+  });
 
   function _addEventListener(target, type, listener) {
     if (target.addEventListener) {

--- a/preview/_/js/previm.js.tmpl
+++ b/preview/_/js/previm.js.tmpl
@@ -273,7 +273,7 @@
   }, REFRESH_INTERVAL);
 
   _addEventListener(_doc, 'scrollend', function() {
-    _win.location.href = _win.location.href.replace(/(#.*)?$/, '#scroll=' + _win.scrollX + ',' + _win.scrollY);
+    _win.location.replace(_win.location.href.replace(/(#.*)?$/, '#scroll=' + _win.scrollX + ',' + _win.scrollY));
   });
 
   function _addEventListener(target, type, listener) {

--- a/preview/_/js/previm.js.tmpl
+++ b/preview/_/js/previm.js.tmpl
@@ -258,9 +258,10 @@
 
     if (isFirstLoad) {
       _addEventListener(script, 'load', function() {
-        if (/#scroll=(\d+),(\d+)$/.test(_win.location.href)) {
-          const x = parseInt(RegExp.$1, 10);
-          const y = parseInt(RegExp.$2, 10);
+        const scrollPosMatch = _win.location.hash.match(/^#scroll=(\d+),(\d+)$/);
+        if (scrollPosMatch != null) {
+          const x = parseInt(scrollPosMatch[1], 10);
+          const y = parseInt(scrollPosMatch[2], 10);
           _win.setTimeout(function() {
             _win.scrollTo(x, y);
           }, 300);


### PR DESCRIPTION
On browser page reload, now page scroll position is reset to the top.

This patch saves scroll position into the fragment part of the page location as `#scroll=X,Y` on every `scrollend` event.
Then, on page load, make it scroll to the saved position.

This is especially for the cases to check included image file update:
browser refresh is required to refetch image data.
