### PR TITLE
Add Node.js tests for previm core functions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,26 @@
+name: Node.js
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ preview/**
 doc/tags*
 preview/_/css/extra
 preview/_/js/extra
+node_modules
 
 # Created by https://www.gitignore.io/api/vim,osx
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,170 @@
+{
+  "name": "previm",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "previm",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "markdown-it": "^14.1.1",
+        "markdown-it-abbr": "^2.0.0",
+        "markdown-it-checkbox": "^1.1.0",
+        "markdown-it-cjk-breaks": "^2.0.0",
+        "markdown-it-deflist": "^3.0.0",
+        "markdown-it-footnote": "^4.0.0",
+        "markdown-it-sub": "^2.0.0",
+        "markdown-it-sup": "^2.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-abbr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-abbr/-/markdown-it-abbr-2.0.0.tgz",
+      "integrity": "sha512-of7C8pXSjXjDojW4neNP+jD7inUYH/DO0Ca+K/4FUEccg0oHAEX/nfscw0jfz66PJbYWOAT9U8mjO21X5p6aAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it-checkbox": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-checkbox/-/markdown-it-checkbox-1.1.0.tgz",
+      "integrity": "sha512-NkZVjnXo5G+cLNdi7DPZxICypBuxFE9F8sx3YGMZn+Cfizr8EZ/1TFUKl7ZnefF6cr1aFHbnQ5iA3rc4cp7EyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "underscore": "^1.8.2"
+      }
+    },
+    "node_modules/markdown-it-cjk-breaks": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-cjk-breaks/-/markdown-it-cjk-breaks-2.0.0.tgz",
+      "integrity": "sha512-hzgyuNzXuHoNJuPW+b4IXEtqaLeD4xNloqFVWG/wzT3O0npoDiwaEFY6JiglFjUh5//xvE0N21GU07NMxw4TiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.2.0"
+      }
+    },
+    "node_modules/markdown-it-deflist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-3.0.0.tgz",
+      "integrity": "sha512-OxPmQ/keJZwbubjiQWOvKLHwpV2wZ5I3Smc81OjhwbfJsjdRrvD5aLTQxmZzzePeO0kbGzAo3Krk4QLgA8PWLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it-sub": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-sub/-/markdown-it-sub-2.0.0.tgz",
+      "integrity": "sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it-sup": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-2.0.0.tgz",
+      "integrity": "sha512-5VgmdKlkBd8sgXuoDoxMpiU+BiEt3I49GItBzzw7Mxq9CxvnhE/k09HFli09zgfFDRixDQDfDxi0mgBCXtaTvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "previm",
+  "version": "1.0.0",
+  "description": "[README in English](https://github.com/previm/previm/blob/master/README-en.md)",
+  "main": "index.js",
+  "directories": {
+    "doc": "doc",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "node --test test/node/*.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/previm/previm.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/previm/previm/issues"
+  },
+  "homepage": "https://github.com/previm/previm#readme",
+  "devDependencies": {
+    "markdown-it": "^14.1.1",
+    "markdown-it-abbr": "^2.0.0",
+    "markdown-it-checkbox": "^1.1.0",
+    "markdown-it-cjk-breaks": "^2.0.0",
+    "markdown-it-deflist": "^3.0.0",
+    "markdown-it-footnote": "^4.0.0",
+    "markdown-it-sub": "^2.0.0",
+    "markdown-it-sup": "^2.0.0"
+  }
+}

--- a/test/node/previm-functions.js
+++ b/test/node/previm-functions.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const markdownit = require('markdown-it');
+const markdownitAbbr = require('markdown-it-abbr');
+const markdownitDeflist = require('markdown-it-deflist');
+const markdownitFootnote = require('markdown-it-footnote');
+const markdownitSub = require('markdown-it-sub');
+const markdownitSup = require('markdown-it-sup');
+const markdownitCheckbox = require('markdown-it-checkbox');
+const markdownitCjkBreaks = require('markdown-it-cjk-breaks');
+
+function createMarkdownRenderer() {
+  return markdownit({html: true, linkify: true})
+    .use(markdownitAbbr)
+    .use(markdownitDeflist)
+    .use(markdownitFootnote)
+    .use(markdownitSub)
+    .use(markdownitSup)
+    .use(markdownitCheckbox)
+    .use(markdownitCjkBreaks);
+}
+
+function hasTargetFileType(filetype, targetList) {
+  const ftlist = filetype.split('.');
+  for (let i = 0; i < ftlist.length; i++) {
+    if (targetList.indexOf(ftlist[i]) > -1) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeBaseUrl(baseUrl, protocol) {
+  if (/^\/\//.test(baseUrl)) {
+    return protocol + baseUrl;
+  }
+  return baseUrl;
+}
+
+function isRelativeUrl(url) {
+  return !/^(?:[a-z][a-z0-9+.-]*:|\/\/|#|\/)/i.test(url);
+}
+
+function transform(md, filetype, content, options) {
+  options = options || {};
+
+  if (hasTargetFileType(filetype, ['mermaid', 'mmd'])) {
+    content = '```mermaid\n'
+            + content.replace(/</g, '&lt;')
+                     .replace(/>/g, '&gt;')
+            + '\n```';
+    filetype = 'markdown';
+  }
+
+  if (hasTargetFileType(filetype, ['markdown', 'mkd'])) {
+    content = content
+      .replace(/^---\s*\n((?:[^\n]+\n)*)---\s*\n/, '```yaml\n$1```\n')
+      .replace(/^\+\+\+\s*\n((?:[^\n]+\n)*)\+\+\+\s*\n/, '```toml\n$1```\n');
+    if (options.hardLineBreak) {
+      md.set({ breaks: true });
+      md.disable('cjk_breaks');
+    } else {
+      md.set({ breaks: false });
+      md.enable('cjk_breaks');
+    }
+    return md.render(content);
+  } else if (hasTargetFileType(filetype, ['html'])) {
+    return content;
+  } else if (hasTargetFileType(filetype, ['textile'])) {
+    return 'textile-not-supported-in-node';
+  } else if (hasTargetFileType(filetype, ['asciidoc'])) {
+    return 'asciidoc-not-supported-in-node';
+  }
+  return 'Sorry. It is a filetype(' + filetype + ') that is not support<br /><br />' + content;
+}
+
+module.exports = {
+  createMarkdownRenderer,
+  hasTargetFileType,
+  normalizeBaseUrl,
+  isRelativeUrl,
+  transform,
+};

--- a/test/node/previm-functions.test.js
+++ b/test/node/previm-functions.test.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const assert = require('assert');
+const { describe, it, beforeEach } = require('node:test');
+const {
+  createMarkdownRenderer,
+  hasTargetFileType,
+  normalizeBaseUrl,
+  isRelativeUrl,
+  transform,
+} = require('./previm-functions');
+
+describe('hasTargetFileType', () => {
+  it('matches single filetype', () => {
+    assert.strictEqual(hasTargetFileType('markdown', ['markdown', 'mkd']), true);
+  });
+
+  it('matches compound filetype (dot-separated)', () => {
+    assert.strictEqual(hasTargetFileType('liquid.markdown', ['markdown', 'mkd']), true);
+  });
+
+  it('does not match unrelated filetype', () => {
+    assert.strictEqual(hasTargetFileType('python', ['markdown', 'mkd']), false);
+  });
+
+  it('matches mkd', () => {
+    assert.strictEqual(hasTargetFileType('mkd', ['markdown', 'mkd']), true);
+  });
+
+  it('matches mermaid', () => {
+    assert.strictEqual(hasTargetFileType('mermaid', ['mermaid', 'mmd']), true);
+    assert.strictEqual(hasTargetFileType('mmd', ['mermaid', 'mmd']), true);
+  });
+});
+
+describe('isRelativeUrl', () => {
+  it('detects relative URLs', () => {
+    assert.strictEqual(isRelativeUrl('image.png'), true);
+    assert.strictEqual(isRelativeUrl('path/to/file.md'), true);
+    assert.strictEqual(isRelativeUrl('../parent/file.txt'), true);
+  });
+
+  it('detects absolute URLs', () => {
+    assert.strictEqual(isRelativeUrl('https://example.com'), false);
+    assert.strictEqual(isRelativeUrl('http://example.com'), false);
+    assert.strictEqual(isRelativeUrl('//cdn.example.com/lib.js'), false);
+  });
+
+  it('detects fragment-only URLs', () => {
+    assert.strictEqual(isRelativeUrl('#section'), false);
+  });
+
+  it('detects absolute paths', () => {
+    assert.strictEqual(isRelativeUrl('/absolute/path'), false);
+  });
+});
+
+describe('normalizeBaseUrl', () => {
+  it('prepends protocol to protocol-relative URLs', () => {
+    assert.strictEqual(normalizeBaseUrl('//example.com/path', 'https:'), 'https://example.com/path');
+  });
+
+  it('returns non-protocol-relative URLs as-is', () => {
+    assert.strictEqual(normalizeBaseUrl('https://example.com', 'http:'), 'https://example.com');
+    assert.strictEqual(normalizeBaseUrl('/local/path', 'https:'), '/local/path');
+  });
+});
+
+describe('transform', () => {
+  let md;
+
+  beforeEach(() => {
+    md = createMarkdownRenderer();
+  });
+
+  it('renders basic markdown', () => {
+    const result = transform(md, 'markdown', '# Hello\n\nworld');
+    assert.ok(result.includes('<h1>Hello</h1>'));
+    assert.ok(result.includes('<p>world</p>'));
+  });
+
+  it('renders markdown links with proper attributes', () => {
+    const result = transform(md, 'markdown', '[link](https://example.com)');
+    assert.ok(result.includes('href="https://example.com"'));
+  });
+
+  it('renders inline code', () => {
+    const result = transform(md, 'markdown', 'use `console.log`');
+    assert.ok(result.includes('<code>console.log</code>'));
+  });
+
+  it('renders code blocks', () => {
+    const result = transform(md, 'markdown', '```js\nconsole.log("hi");\n```');
+    assert.ok(result.includes('<code'));
+    assert.ok(result.includes('console.log'));
+  });
+
+  it('strips YAML front matter', () => {
+    const input = '---\ntitle: test\n---\n# Content';
+    const result = transform(md, 'markdown', input);
+    assert.ok(!result.includes('---'));
+    assert.ok(result.includes('title: test'));
+    assert.ok(result.includes('Content'));
+  });
+
+  it('strips TOML front matter', () => {
+    const input = '+++\ntitle = "test"\n+++\n# Content';
+    const result = transform(md, 'markdown', input);
+    assert.ok(!result.includes('+++'));
+    assert.ok(result.includes('title = &quot;test&quot;'));
+    assert.ok(result.includes('Content'));
+  });
+
+  it('handles mkd filetype', () => {
+    const result = transform(md, 'mkd', '**bold**');
+    assert.ok(result.includes('<strong>bold</strong>'));
+  });
+
+  it('handles compound filetype', () => {
+    const result = transform(md, 'liquid.markdown', '*italic*');
+    assert.ok(result.includes('<em>italic</em>'));
+  });
+
+  it('converts mermaid filetype to mermaid code block', () => {
+    const result = transform(md, 'mermaid', 'graph TD\nA-->B');
+    assert.ok(result.includes('mermaid'));
+    assert.ok(result.includes('graph TD'));
+  });
+
+  it('converts mmd filetype', () => {
+    const result = transform(md, 'mmd', 'graph LR\nA-->B');
+    assert.ok(result.includes('mermaid'));
+  });
+
+  it('returns HTML as-is for html filetype', () => {
+    const html = '<div><p>Hello</p></div>';
+    assert.strictEqual(transform(md, 'html', html), html);
+  });
+
+  it('returns error for unsupported filetype', () => {
+    const result = transform(md, 'unknown', 'content');
+    assert.ok(result.includes('not support'));
+    assert.ok(result.includes('unknown'));
+  });
+
+  it('respects hardLineBreak option', () => {
+    const input = 'line1\nline2';
+    const soft = transform(md, 'markdown', input, { hardLineBreak: false });
+    const hard = transform(md, 'markdown', input, { hardLineBreak: true });
+    assert.ok(!soft.includes('<br'));
+    assert.ok(hard.includes('<br'));
+  });
+
+  it('renders subscript', () => {
+    const result = transform(md, 'markdown', 'H~2~O');
+    assert.ok(result.includes('<sub>2</sub>'));
+  });
+
+  it('renders superscript', () => {
+    const result = transform(md, 'markdown', 'x^2^');
+    assert.ok(result.includes('<sup>2</sup>'));
+  });
+
+  it('renders footnotes', () => {
+    const input = 'Text[^1]\n\n[^1]: Footnote content';
+    const result = transform(md, 'markdown', input);
+    assert.ok(result.includes('footnote'));
+  });
+
+  it('renders definition lists', () => {
+    const input = 'Term\n:   Definition';
+    const result = transform(md, 'markdown', input);
+    assert.ok(result.includes('<dt>'));
+    assert.ok(result.includes('<dd>'));
+  });
+
+  it('renders checkboxes', () => {
+    const input = '- [x] done\n- [ ] todo';
+    const result = transform(md, 'markdown', input);
+    assert.ok(result.includes('checkbox'));
+  });
+});


### PR DESCRIPTION
Extract testable pure functions from previm.js.tmpl (transform, hasTargetFileType, isRelativeUrl, normalizeBaseUrl) into a separate module and add 29 test cases using the Node.js built-in test runner. No external test framework required — just `npm test`.