### PR TITLE
[codex] Split WSL open path handling

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -17,8 +17,7 @@ function! previm#open(preview_html_file) abort
     elseif has('win32unix')
       call s:system(g:previm_open_cmd . ' '''  . system('cygpath -w ' . a:preview_html_file) . '''')
     elseif get(g:, 'previm_wsl_mode', 0) ==# 1
-      let wsl_file_path = trim(system('wslpath -w ' . a:preview_html_file), "\r\n", 2)
-      call s:system(g:previm_open_cmd . " 'file:///" . fnamemodify(wsl_file_path, ':gs?\\?\/?') . '''')
+      call s:system(g:previm_open_cmd . " '" . previm#wsl_open_path(a:preview_html_file) . '''')
     elseif has('win32')
       call s:system(g:previm_open_cmd . ' "'  . a:preview_html_file . '"')
     else
@@ -42,6 +41,17 @@ function! previm#open(preview_html_file) abort
     au!
     au VimLeave * call previm#wipe_cache_for_self()
   augroup END
+endfunction
+
+function! previm#wsl_open_path(preview_html_file, ...) abort
+  if get(g:, 'previm_wsl_open_path_format', 'windows') ==# 'wsl'
+    return a:preview_html_file
+  endif
+
+  let wsl_file_path = a:0 > 0
+        \ ? a:1
+        \ : trim(system('wslpath -w ' . a:preview_html_file), "\r\n", 2)
+  return 'file:///' . fnamemodify(wsl_file_path, ':gs?\\?\/?')
 endfunction
 
 function! s:exists_openbrowser() abort

--- a/doc/previm.jax
+++ b/doc/previm.jax
@@ -94,6 +94,25 @@ g:previm_open_cmd					*g:previm_open_cmd*
         let g:previm_open_cmd = 'open -a Google\ Chrome'
 <
 
+g:previm_wsl_open_path_format			*g:previm_wsl_open_path_format*
+	型:文字列
+
+	|g:previm_wsl_mode| が1のとき、|g:previm_open_cmd| に渡すプレビュー
+	HTMLのパス形式を指定します。
+
+	有効な値は以下です。
+	  windows	プレビューHTMLのパスを wslpath -w で変換し、Windows の
+			file:/// URLとして渡します。デフォルト値で、従来と同じ
+			動作です。
+	  wsl		プレビューHTMLのパスをWSLのパスのまま渡します。
+			|g:previm_open_cmd| に wslview を使う場合に指定します。
+>
+	" .vimrc
+	let g:previm_wsl_mode = 1
+	let g:previm_open_cmd = 'wslview'
+	let g:previm_wsl_open_path_format = 'wsl'
+<
+
 g:previm_enable_realtime			*g:previm_enable_realtime*
 	型:数値
 
@@ -332,4 +351,3 @@ open-browser.vimの使用					*previm-openbrowser*
 	- 初版
 
 vim:tw=78:ts=8:ft=help:norl:
-

--- a/doc/previm.txt
+++ b/doc/previm.txt
@@ -104,6 +104,25 @@ g:previm_open_cmd					*g:previm_open_cmd*
         let g:previm_open_cmd = 'open -a Google\ Chrome'
 <
 
+g:previm_wsl_open_path_format			*g:previm_wsl_open_path_format*
+	Type:String
+
+	Specify the preview HTML path format passed to |g:previm_open_cmd| when
+	|g:previm_wsl_mode| is 1.
+
+	Supported values are:
+	  windows	Convert the preview HTML path with wslpath -w and pass it
+			as a Windows file:/// URL. This is the default and preserves
+			the previous behavior.
+	  wsl		Pass the preview HTML path as a WSL path. Use this when
+			|g:previm_open_cmd| is wslview.
+>
+	" .vimrc
+	let g:previm_wsl_mode = 1
+	let g:previm_open_cmd = 'wslview'
+	let g:previm_wsl_open_path_format = 'wsl'
+<
+
 g:previm_enable_realtime			*g:previm_enable_realtime*
 	Type:Num
 

--- a/test/autoload/previm_test.vim
+++ b/test/autoload/previm_test.vim
@@ -35,6 +35,43 @@ function! s:t.exists_double_quotes()
   call s:assert.equals(previm#convert_to_content(arg), expected)
 endfunction
 "}}}
+let s:t = themis#suite('wsl_open_path') "{{{
+
+function! s:t.setup()
+  let self.exists_previm_wsl_open_path_format = exists('g:previm_wsl_open_path_format')
+  if self.exists_previm_wsl_open_path_format
+    let self.previm_wsl_open_path_format = g:previm_wsl_open_path_format
+  endif
+endfunction
+
+function! s:t.teardown()
+  if self.exists_previm_wsl_open_path_format
+    let g:previm_wsl_open_path_format = self.previm_wsl_open_path_format
+  else
+    unlet! g:previm_wsl_open_path_format
+  endif
+endfunction
+
+function! s:t.default_windows_path()
+  let actual = previm#wsl_open_path('/tmp/previm/index.html', 'C:\Users\me\AppData\Local\Temp\previm\index.html')
+  let expected = 'file:///C:/Users/me/AppData/Local/Temp/previm/index.html'
+  call s:assert.equals(actual, expected)
+endfunction
+
+function! s:t.windows_path()
+  let g:previm_wsl_open_path_format = 'windows'
+  let actual = previm#wsl_open_path('/tmp/previm/index.html', 'C:\Users\me\AppData\Local\Temp\previm\index.html')
+  let expected = 'file:///C:/Users/me/AppData/Local/Temp/previm/index.html'
+  call s:assert.equals(actual, expected)
+endfunction
+
+function! s:t.wsl_path()
+  let g:previm_wsl_open_path_format = 'wsl'
+  let actual = previm#wsl_open_path('/tmp/previm/index.html', 'C:\Users\me\AppData\Local\Temp\previm\index.html')
+  let expected = '/tmp/previm/index.html'
+  call s:assert.equals(actual, expected)
+endfunction
+"}}}
 let s:t = themis#suite('relative_to_absolute') "{{{
 
 function! s:t.nothing_when_empty()


### PR DESCRIPTION
## Summary

- Add `g:previm_wsl_open_path_format` for WSL `:PrevimOpen` path handling.
- Preserve the existing default behavior by converting preview paths with `wslpath -w` and passing Windows `file:///` URLs.
- Support `wslview` by allowing `g:previm_wsl_open_path_format = 'wsl'`, which passes the WSL path directly.
- Document the new option in English and Japanese help, and add tests for both path formats.

Fixes #244.

## Validation

- `/tmp/previm-vim-themis/bin/themis test -r --reporter dot`
- `git diff --check`